### PR TITLE
Prepare plugin for usage in Crowd 4.0 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>de.aservo</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.9</version>
     </parent>
 
     <groupId>de.aservo.atlassian</groupId>
     <artifactId>crowd-timestamp-to-date-plugin</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
     <packaging>atlassian-plugin</packaging>
 
     <name>Timestamp-to-Date for Atlassian Crowd</name>
@@ -51,17 +51,11 @@
     </developers>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <crowd.version>3.3.3</crowd.version>
-        <crowd.data.version>3.3.3</crowd.data.version>
-        <amps.version>8.0.0</amps.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
-        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
-        <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
+        <crowd.version>4.0.0</crowd.version>
+        <amps.version>8.0.2</amps.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
+        <atlassian.spring.scanner.version>2.1.11</atlassian.spring.scanner.version>
+        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
     </properties>
 
     <dependencyManagement>
@@ -80,15 +74,7 @@
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -107,7 +93,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <productVersion>${crowd.version}</productVersion>
-                    <productDataVersion>${crowd.data.version}</productDataVersion>
+                    <productDataVersion>${crowd.version}</productDataVersion>
                     <allowGoogleTracking>false</allowGoogleTracking>
                     <enableQuickReload>true</enableQuickReload>
                     <!-- See here for an explanation of default instructions: -->

--- a/src/main/resources/META-INF/spring/plugin-context.xml
+++ b/src/main/resources/META-INF/spring/plugin-context.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:atlassian-scanner="http://www.atlassian.com/schema/atlassian-scanner/2"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.atlassian.com/schema/atlassian-scanner
-        http://www.atlassian.com/schema/atlassian-scanner/atlassian-scanner.xsd">
+        http://www.atlassian.com/schema/atlassian-scanner/2
+        http://www.atlassian.com/schema/atlassian-scanner/2/atlassian-scanner.xsd">
     <atlassian-scanner:scan-indexes/>
 </beans>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -8,8 +8,8 @@
     </plugin-info>
 
     <web-resource key="crowd-timestamp-to-date-plugin-resources" name="crowd-timestamp-to-date-plugin Web Resources">
-        <resource type="download" name="timestamp-to-date.js" location="js/crowd-timestamp-to-date-plugin.js"/>
         <dependency>com.atlassian.auiplugin:ajs</dependency>
+        <resource type="download" name="timestamp-to-date-plugin.js" location="js/crowd-timestamp-to-date-plugin.js"/>
         <context>atl.admin</context>
     </web-resource>
 </atlassian-plugin>

--- a/src/main/resources/js/crowd-timestamp-to-date-plugin.js
+++ b/src/main/resources/js/crowd-timestamp-to-date-plugin.js
@@ -19,19 +19,11 @@ AJS.$(document).ready(function () {
         var date = parseTimestampValue(element);
 
         if (date) {
-            AJS.InlineDialog(element, "dateDialog" + i,
-                function(content, trigger, showPopup) {
-                    var date = parseTimestampValue(element);
-
-                    content.css({"padding":"20px","color":"#000"}).html('<p>' + date + '</p>');
-                    showPopup();
-                    return false;
-                },{
-                    onHover: true,
-                    closeOnTriggerClick: true,
-                    hideDelay: 0
+            element.tooltip({
+                title: function () {
+                    return parseTimestampValue(element);
                 }
-            );
+            });
         }
     });
 });


### PR DESCRIPTION
This commit updates the POM for the usage in Crowd 4.0 and above. It includes
updating the used Crowd version and changing over from Spring Scanner 1 to 2.

The next step will be to replace the old inline dialog by the inline dialog 2
which also requires to replace the old javascript code by using the web
component API with HTML (documentation source unknown yet).

Then, the following HTML can be used for creating the inline dialogs:

https://docs.atlassian.com/aui/8.6.0/docs/inline-dialog.html